### PR TITLE
Documentation update + error code 4 fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,12 +5,13 @@ Script that allows the easy creation of OpenVPN endpoints in any AWS region.  To
 [![asciicast](https://asciinema.org/a/40608.png)](https://asciinema.org/a/40608)
 
 Dependencies:
+
 0. Install boto by running: 
-	<pre><code>pip install boto</pre></code>
+	<pre><addr>pip install boto</pre></addr>
 1. Install paramiko by running: 
-	<pre><code>pip install paramiko</pre></code>
+	<pre><addr>pip install paramiko</pre></addr>
 2. Ensure that you have an AWS .credentials file by running: 
-	<pre><code>nano ~/.aws/credentials</pre></code>
+	<pre><addr>nano ~/.aws/credentials</pre></addr>
 	Then type in the following and add your keys (remove <>):
 	<pre><code>
 	[Credentials]
@@ -21,13 +22,14 @@ Dependencies:
 
 
 Installation:
-0. Ensure dependencies are all installed.
-1. Clone repo to system.
-2. Execute autovpn with -C -k and -r options to deploy to AWS
+
+1. Ensure dependencies are all installed.
+2. Clone repo to system.
+3. Execute autovpn with -C -k and -r options to deploy to AWS
 	`./autovpn -C -r us-east-1 -k us-east-1_vpnkey`
-3. OpenVPN config files are downloaded to current working directory.
-4. Import the OpenVPN config file and connect:
-	<pre><code>sudo openvpn us-east-1_aws_vpn.ovpn</pre></code>
+4. OpenVPN config files are downloaded to current working directory.
+5. Import the OpenVPN config file and connect:
+	<pre><addr>sudo openvpn us-east-1_aws_vpn.ovpn</pre></addr>
 
 <pre><code>
 DESCRIPTION:
@@ -65,11 +67,9 @@ EXAMPLES:
   Using custom options
     autovpn -C -r us-east-1 -k us-east-1_vpnkey -a ami-fce3c696 -u ec2_user -i m3.medium
 NOTES:
-        \* - Customs ami may be needed if changing instance type.
-       	\** - In reality any instance size can be given but the t2.micro is more than
-       	 enough.
+        \* - Custom AMI may be needed if changing instance type.
+        \** - Any instance size can be given but the t2.micro is more than enough.
         \*** - Custom user might be need if using a custom ami.
-	\**** - The AWS IAM user (used in ~/.aws/credentials file) must have EC2 or Administrator permissions set.
-	\***** - You'll need to install the OpenVPN client on your system if you plan on connecting to VPN with it.
+	\**** - AWS IAM user must have EC2 or Administrator permissions set.
 
 </pre></code>

--- a/README.md
+++ b/README.md
@@ -6,27 +6,27 @@ Script that allows the easy creation of OpenVPN endpoints in any AWS region.  To
 
 Dependencies:
 
-0. Install boto by running: 
+1. Install boto by running: 
 	<pre><addr>pip install boto</pre></addr>
-1. Install paramiko by running: 
+2. Install paramiko by running: 
 	<pre><addr>pip install paramiko</pre></addr>
-2. Ensure that you have an AWS .credentials file by running: 
+3. Ensure that you have an AWS .credentials file by running: 
 	<pre><addr>nano ~/.aws/credentials</pre></addr>
-	Then type in the following and add your keys (remove <>):
+	Then type in the following and add your keys (remove parenthesis):
 	<pre><code>
 	[Credentials]
-	aws_access_key_id = <your_access_key_here>
-	aws_secret_access_key = <your_secret_key_here>
+	aws_access_key_id = (your_access_key_here)
+	aws_secret_access_key = (your_secret_key_here)
 	</pre></code>
-3. Install OpenVPN client (if needed)
+4. Install OpenVPN client (if needed)
 
 
 Installation:
 
 1. Ensure dependencies are all installed.
 2. Clone repo to system.
-3. Execute autovpn with -C -k and -r options to deploy to AWS
-	`./autovpn -C -r us-east-1 -k us-east-1_vpnkey`
+3. Execute autovpn with -C -k and -r options to deploy to AWS:
+	<pre><addr>./autovpn -C -r us-east-1 -k us-east-1_vpnkey</addr>
 4. OpenVPN config files are downloaded to current working directory.
 5. Import the OpenVPN config file and connect:
 	<pre><addr>sudo openvpn us-east-1_aws_vpn.ovpn</pre></addr>
@@ -70,6 +70,6 @@ NOTES:
         \* - Custom AMI may be needed if changing instance type.
         \** - Any instance size can be given but the t2.micro is more than enough.
         \*** - Custom user might be need if using a custom ami.
-	\**** - AWS IAM user must have EC2 or Administrator permissions set.
+	      \**** - AWS IAM user must have EC2 or Administrator permissions set.
 
 </pre></code>

--- a/README.md
+++ b/README.md
@@ -4,14 +4,30 @@ Script that allows the easy creation of OpenVPN endpoints in any AWS region.  To
 
 [![asciicast](https://asciinema.org/a/40608.png)](https://asciinema.org/a/40608)
 
-Dependencies: boto and paramiko (python packages) and aws .credentials file on system
+Dependencies:
+0. Install boto by running: 
+	<pre><code>pip install boto</pre></code>
+1. Install paramiko by running: 
+	<pre><code>pip install paramiko</pre></code>
+2. Ensure that you have an AWS .credentials file by running: 
+	<pre><code>nano ~/.aws/credentials</pre></code>
+	Then type in the following and add your keys (remove <>):
+	<pre><code>
+	[Credentials]
+	aws_access_key_id = <your_access_key_here>
+	aws_secret_access_key = <your_secret_key_here>
+	</pre></code>
+3. Install OpenVPN client (if needed)
 
+
+Installation:
+0. Ensure dependencies are all installed.
 1. Clone repo to system.
 2. Execute autovpn with -C -k and -r options to deploy to AWS
-	`./autovpn -C -r us-east-1 -k macbook`
+	`./autovpn -C -r us-east-1 -k us-east-1_vpnkey`
 3. OpenVPN config files are downloaded to current working directory.
-4. Import the OpenVPN config file into VPN client.
-5. Connect to VPN.
+4. Import the OpenVPN config file and connect:
+	<pre><code>sudo openvpn us-east-1_aws_vpn.ovpn</pre></code>
 
 <pre><code>
 DESCRIPTION:
@@ -39,7 +55,7 @@ USAGE:
        -z    Specify instance id.
 EXAMPLES:
   Create OpenVPN endpoint:
-	autovpn -C -r us-east-1 -k macbook
+	autovpn -C -r us-east-1 -k us-east-1_vpnkey
   Generate keypair in a region.
 	autovpn -G -r us-east-1
   Get running instances
@@ -47,11 +63,13 @@ EXAMPLES:
   Terminate OpenVPN endpoint
 	autovpn -T -r us-east-1 -z i-b933e00c
   Using custom options
-    autovpn -C -r us-east-1 -k macbook -a ami-fce3c696 -u ec2_user -i m3.medium
+    autovpn -C -r us-east-1 -k us-east-1_vpnkey -a ami-fce3c696 -u ec2_user -i m3.medium
 NOTES:
         \* - Customs ami may be needed if changing instance type.
        	\** - In reality any instance size can be given but the t2.micro is more than
        	 enough.
         \*** - Custom user might be need if using a custom ami.
+	\**** - The AWS IAM user (used in ~/.aws/credentials file) must have EC2 or Administrator permissions set.
+	\***** - You'll need to install the OpenVPN client on your system if you plan on connecting to VPN with it.
 
 </pre></code>

--- a/README.md
+++ b/README.md
@@ -70,6 +70,6 @@ NOTES:
         \* - Custom AMI may be needed if changing instance type.
         \** - Any instance size can be given but the t2.micro is more than enough.
         \*** - Custom user might be need if using a custom ami.
-	      \**** - AWS IAM user must have EC2 or Administrator permissions set.
+	    \**** - AWS IAM user must have EC2 or Administrator permissions set.
 
 </pre></code>

--- a/autovpn
+++ b/autovpn
@@ -35,10 +35,10 @@ function usage {
   $white-u$gray\t Specify custom ssh user.***
   $white-y$gray\t Skip confirmations
   $white-z$gray\t Specify instance id." 
-  echo -e "${white}EXAMPLES:\n $gray Create OpenVPN endpoint: \n\tautovpn -C -r us-east-1 -k macbook\n\
+  echo -e "${white}EXAMPLES:\n $gray Create OpenVPN endpoint: \n\tautovpn -C -r us-east-1 -k us-east-1_vpnkey\n\
   Generate keypar in a region.\n\tautovpn -G -r us-east-1\n  Get running instances\n\tautovpn -S -r us-west-1\n\
   Terminate OpenVPN endpoint\n\tautovpn -T -r us-west-1 -z i-b933e00c\n  Using custom options\n\
-  \tautovpn -C -r us-east-1 -k macbook -a ami-fce3c696 -u ec2_user -i m3.medium"
+  \tautovpn -C -r us-east-1 -k us-east-1_vpnkey -a ami-fce3c696 -u ec2_user -i m3.medium"
   echo -e "${white}NOTES:\n $gray* - Customs ami may be needed if changing instance type.\n $gray** - In reality any\
   instance size can be given but the t2.micro\n is more than enough.\n\
  $gray*** - Custom user might be need if using a custom ami."

--- a/scripts/keygen.py
+++ b/scripts/keygen.py
@@ -11,7 +11,6 @@ key_dir=sys.argv[3]
 conn_region = boto.ec2.connect_to_region(region)
 
 def generate_key(key_name=keyname,
-                    key_extension='.pem',
                     key_dir=key_dir,
                     ssh_passwd=None):
 


### PR DESCRIPTION
When autovpn generates new keys, it appends the filename with a .pem extension. The file is then added to your AWS account region key store but does not have a .pem extension. When you try to run autovpn and add the -k with the us-west-1_vpnkey.pem filename, they don't match with the key pair name that AWS has (same name without the .pem).

Updated the README and autovpn help to clarify usage