### PR TITLE
Workaround broken Boto key save

### DIFF
--- a/scripts/keygen.py
+++ b/scripts/keygen.py
@@ -26,7 +26,9 @@ def generate_key(key_name=keyname,
             key = ec2.create_key_pair(key_name)
 
             # Save key
-            key.save(key_dir)
+            save_key_path = "%s/%s.pem" %(key_dir, key_name)
+            with open(save_key_path, "w") as file:
+                file.write(key.material)
             print("Success")
         else:
             raise


### PR DESCRIPTION
Boto3 appears to be bugged in some way and can't properly execute the key.save(dir) function. 

```
rotary :: projects/autovpn » ./autovpn -G -r us-west-1                          
Generating new keypair for us-west-1.
Traceback (most recent call last):
  File "./scripts/keygen.py", line 21, in generate_key
    key = ec2.get_all_key_pairs(keynames=[key_name])[0]
  File "/home/rotary/.local/lib/python3.7/site-packages/boto/ec2/connection.py", line 2836, in get_all_key_pairs
    [('item', KeyPair)], verb='POST')
  File "/home/rotary/.local/lib/python3.7/site-packages/boto/connection.py", line 1186, in get_list
    raise self.ResponseError(response.status, response.reason, body)
boto.exception.EC2ResponseError: EC2ResponseError: 400 Bad Request
<?xml version="1.0" encoding="UTF-8"?>
<Response><Errors><Error><Code>InvalidKeyPair.NotFound</Code><Message>The key pair 'us-west-1_vpnkey' does not exist</Message></Error></Errors><RequestID>b3cab400-871c-4f37-a3ac-2ad872d8f1dc</RequestID></Response>

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "./scripts/keygen.py", line 36, in <module>
    generate_key()
  File "./scripts/keygen.py", line 29, in generate_key
    key.save(key_dir)
  File "/home/rotary/.local/lib/python3.7/site-packages/boto/ec2/keypair.py", line 85, in save
    fp.write(self.material)
TypeError: a bytes-like object is required, not 'str'
Key already exists in AWS
```

Possible to workaround this by writing key.material directly in keygen.py:

```python
save_key_path = "%s/%s.pem" %(key_dir, key_name)
with open(save_key_path, "w") as file: 
    file.write(key.material)
print("Success")
```